### PR TITLE
Changed old https field from 'https' to 'use_cert'.

### DIFF
--- a/src/metrics.js
+++ b/src/metrics.js
@@ -7,7 +7,7 @@ const axios = require('axios');
 const prometheus = require('prom-client');
 
 // Config
-const { appurl, appport, https, dds, rmf3interval } = require('./config/Zconfig.json');
+const { appurl, appport, use_cert, dds, rmf3interval } = require('./config/Zconfig.json');
 
 // Metrics in memory
 const metrics = require('./metrics.json');
@@ -47,7 +47,7 @@ setInterval(async () => {
         for (const request in requests) {
             var [ report, resource ] = request.split(" ")
             // Get XML data from DDS (this method is more efficient than calling our own API with axios)
-            await axios.get(`${https}://${appurl}:${appport}/v1/${lpar}/rmf3/${report}?resource=${resource}`)
+            await axios.get(`${use_cert}://${appurl}:${appport}/v1/${lpar}/rmf3/${report}?resource=${resource}`)
                 .then((response) => {
                     // Loop through metrics using this report
                     const result = response.data;


### PR DESCRIPTION
Fixes #62

The issue was that the `metrics.js` file was still using the old `Zconfig.json` field `https` as opposed to the latest `use_cert`. This was causing the protocol of the requests to always be HTTP. Renaming references to the old field to the new one fixes the issue.

Signed-off-by: Justin Santer <justin.santer@convergetp.com>