### PR TITLE
fix: restored createError import to handle 404 routes properly

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -22,6 +22,7 @@ try {
 
 
 var ddsconfig = require("./config/Zconfig.json"); */
+var createError = require('http-errors');
 var express = require('express');
 var path = require('path');
 var cookieParser = require('cookie-parser');


### PR DESCRIPTION
## Issue Solved: #126
## PR summary
This PR solves issue #126 by uncommenting this line: `var createError = require('http-errors');` in the file `/src/app.js`.
Now navigating to any undefined page throws proper 404 (not found) error.
## Screenshots
### Previously
![Screenshot from 2025-05-14 02-08-18](https://github.com/user-attachments/assets/8c2c4760-0275-4c00-9ccc-d96361db7225)

### After this PR
![Screenshot from 2025-05-14 02-06-53](https://github.com/user-attachments/assets/faafe086-90ab-446a-8290-7d1851d38531)

This PR is fairly simple with ninor changes in 1 file and ready for review.
Thanks.